### PR TITLE
fix test_00814

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1764,7 +1764,13 @@ ReplicatedMergeTreeMergePredicate::ReplicatedMergeTreeMergePredicate(
     Strings partitions = zookeeper->getChildren(queue.replica_path + "/parts");
     for (const String & partition : partitions)
     {
-        auto header = ReplicatedMergeTreePartHeader::fromString(zookeeper->get(queue.replica_path + "/parts/" + partition));
+        auto part_str = zookeeper->get(queue.replica_path + "/parts/" + partition);
+        if (part_str.empty())
+        {
+            /// use_minimalistic_part_header_in_zookeeper
+            continue;
+        }
+        auto header = ReplicatedMergeTreePartHeader::fromString(part_str);
         if (header.getBlockID())
         {
             ReplicatedMergeTreeBlockEntry block(zookeeper->get(queue.zookeeper_path + "/blocks/" + *header.getBlockID()));


### PR DESCRIPTION
ReplicatedMergeTreeMergePredicate: if not use_minimalistic_part_header_in_zookeeper, should skip these parts (can't be used for parallel quorum inserts)